### PR TITLE
Fix second run with apparmor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ install_apparmor:
 	install -d -m 755 "$(DESTDIR)"/etc/apparmor.d
 	install -d -m 755 "$(DESTDIR)"/etc/apparmor.d/local
 	install -m 644 profiles/apparmor.d/opt.openqa-trigger-from-obs.script.rsync.sh "$(DESTDIR)"/etc/apparmor.d/
+	install -m 644 profiles/apparmor.d/local/opt.openqa-trigger-from-obs.script.rsync.sh "$(DESTDIR)"/etc/apparmor.d/local/
 	install -m 644 profiles/apparmor.d/local/usr.share.openqa.script.openqa "$(DESTDIR)"/etc/apparmor.d/local/
 
 test:

--- a/profiles/apparmor.d/local/opt.openqa-trigger-from-obs.script.rsync.sh
+++ b/profiles/apparmor.d/local/opt.openqa-trigger-from-obs.script.rsync.sh
@@ -1,0 +1,1 @@
+# Site-specific additions and overrides for 'opt.openqa-trigger-from-obs.script.rsync.sh'

--- a/profiles/apparmor.d/opt.openqa-trigger-from-obs.script.rsync.sh
+++ b/profiles/apparmor.d/opt.openqa-trigger-from-obs.script.rsync.sh
@@ -1,19 +1,30 @@
+# Last Modified: Sat Nov 16 13:01:27 2019
 #include <tunables/global>
 
 /opt/openqa-trigger-from-obs/script/rsync.sh flags=(attach_disconnected) {
   #include <abstractions/base>
 
+  # we don't want rsync.sh to overwrite project-specific files like
+  # read_files.sh print_rsync*.sh print_openqa.sh
+  # which are generated during deplyment
+  # and log files
+  # so rules below are quire pedantic
+  /opt/openqa-trigger-from-obs/** r,
+  /opt/openqa-trigger-from-obs/openSUSE*/.run*/ rw,
+  /opt/openqa-trigger-from-obs/openSUSE*/.run*/* rw,
+  /opt/openqa-trigger-from-obs/openSUSE*/.run_last rw,
+  /opt/openqa-trigger-from-obs/openSUSE*/files*.lst rw,
+  /opt/openqa-trigger-from-obs/openSUSE*/rsync.lock rw,
   /usr/bin/awk ix,
-  /usr/bin/gawk ix,
-  /{usr/bin,bin}/bash mrix,
   /usr/bin/bsdtar ix,
   /usr/bin/cat ix,
   /usr/bin/cp ix,
-  /usr/bin/head ix,
   /usr/bin/date ix,
   /usr/bin/diff ix,
   /usr/bin/dirname ix,
+  /usr/bin/gawk ix,
   /usr/bin/grep ix,
+  /usr/bin/head ix,
   /usr/bin/ln ix,
   /usr/bin/ls ix,
   /usr/bin/mkdir ix,
@@ -21,52 +32,48 @@
   /usr/bin/rsync Px -> /opt/openqa-trigger-from-obs/script/rsync.sh//rsync,
   /usr/bin/sort ix,
   /usr/bin/tee ix,
-
   /usr/share/openqa/script/client rPx -> /opt/openqa-trigger-from-obs/script/rsync.sh//openqa_client,
-
-  /opt/openqa-trigger-from-obs/** r,
-  /opt/openqa-trigger-from-obs/openSUSE*/files*.lst rw,
-  /opt/openqa-trigger-from-obs/openSUSE*/rsync.lock rw,
-  /opt/openqa-trigger-from-obs/openSUSE*/.run_last rw,
-  /opt/openqa-trigger-from-obs/openSUSE*/.run*/ rw,
-  /opt/openqa-trigger-from-obs/openSUSE*/.run*/* rw,
-  /var/lib/openqa/share/factory/{iso,other}/** r,
   /var/lib/openqa/share/factory/repo/** rw, # need write permission because sometimes bsdtar iso here
+  /var/lib/openqa/share/factory/{iso,other}/** r,
+  /{usr/bin,bin}/bash mrix,
+
+  profile openqa_client {
+    #include <abstractions/base>
+    #include <abstractions/nameservice>
+    #include <abstractions/openssl>
+    #include <abstractions/perl>
+    #include <abstractions/ssl_certs>
+
+    capability net_bind_service,
+
+    network tcp,
+
+    /etc/openqa/client.conf r,
+    /opt/openqa-trigger-from-obs/openSUSE*/.run*/openqa*.log w,
+    /usr/share/openqa/lib/** r,
+    /usr/share/openqa/script/client rix,
+    /var/lib/openqa/.config/openqa/client.conf r,
+    /var/lib/openqa/share/factory/{iso,repo,other}/** r,
+
+  }
 
   profile rsync flags=(attach_disconnected) {
     #include <abstractions/base>
     #include <abstractions/nameservice>
 
     capability net_bind_service,
+
     network tcp,
 
-    /usr/bin/rsync mrix,
-
-    /var/lib/openqa/share/factory/{iso,repo,other}/** rw,
     link subset /var/lib/openqa/share/factory/iso/** -> /var/lib/openqa/share/factory/iso/**,
     link subset /var/lib/openqa/share/factory/repo/** -> /var/lib/openqa/share/factory/repo/**,
 
     /opt/openqa-trigger-from-obs/openSUSE*/.run*/rsync*.log w,
-    # /var/lib/docker/** r,
+    /usr/bin/rsync mrix,
+    /var/lib/openqa/share/factory/{iso,repo,other}/** rw,
+
   }
 
-  profile openqa_client {
-    #include <abstractions/base>
-    #include <abstractions/nameservice>
-    #include <abstractions/openssl>
-    #include <abstractions/ssl_certs>
-    #include <abstractions/perl>
-
-    capability net_bind_service,
-    network tcp,
-
-    /usr/share/openqa/script/client rix,
-    /usr/share/openqa/lib/** r,
-    /var/lib/openqa/.config/openqa/client.conf r,
-    /etc/openqa/client.conf r,
-
-    /var/lib/openqa/share/factory/{iso,repo,other}/** r,
-
-    /opt/openqa-trigger-from-obs/openSUSE*/.run*/openqa*.log w,
-  }
+  # Site-specific additions and overrides. See local/README for details.
+  #include <local/opt.openqa-trigger-from-obs.script.rsync.sh>
 }

--- a/script/rsync.sh
+++ b/script/rsync.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 environ=$1
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
@@ -41,7 +41,9 @@ mkdir $logdir
 cp $environ/*.lst $logdir/
 cp $environ/*.sh $logdir/
 
-ln -fs -T "$(pwd)/$logdir" $environ/.run_last
+# remove symbolic link if exists
+[ ! -L "$environ/.run_last" ] || rm "$environ/.run_last"
+ln -s -T "$(pwd)/$logdir" $environ/.run_last
 
 [ ! -e "$environ/print_openqa.sh" ] || bash -e "$environ/print_openqa.sh" 2>$logdir/generate_openqa.err > $logdir/openqa.cmd
 

--- a/t/docker/lib/test-in-container-systemd.sh
+++ b/t/docker/lib/test-in-container-systemd.sh
@@ -120,8 +120,13 @@ docker exec "$containername" pwd >& /dev/null || (echo Cannot start container; e
 # (feel free to remove this line if it is not needed)
 
 echo 'cd /opt/openqa-trigger-from-obs && make install_apparmor' | docker exec -i "$containername" bash -x
+# these are hacks to make apparmor tolerate container
 echo 'sed -i "s,/usr/share/openqa/script/openqa {,/usr/share/openqa/script/openqa flags=(attach_disconnected) {," /etc/apparmor.d/usr.share.openqa.script.openqa' | docker exec -i "$containername" bash -x
-echo 'echo " /var/lib/docker/** r," >> /etc/apparmor.d/local/usr.share.openqa.script.openqa && rcapparmor restart' | docker exec -i "$containername" bash -x
+echo 'echo " /var/lib/docker/** r," >> /etc/apparmor.d/local/usr.share.openqa.script.openqa' | docker exec -i "$containername" bash -x
+echo 'sed -i "s,/opt/openqa-trigger-from-obs/script/rsync.sh {,/opt/openqa-trigger-from-obs/script/rsync.sh flags=(attach_disconnected) {," /etc/apparmor.d/opt.openqa-trigger-from-obs.script.rsync.sh' | docker exec -i "$containername" bash -x
+echo 'sed -i "/\/usr\/bin\/rsync mrix,/a  \/var\/lib\/docker\/** r," /etc/apparmor.d/opt.openqa-trigger-from-obs.script.rsync.sh' | docker exec -i "$containername" bash -x
+echo 'echo " /var/lib/docker/** r," >> /etc/apparmor.d/local/opt.openqa-trigger-from-obs.script.rsync.sh' | docker exec -i "$containername" bash -x
+echo 'rcapparmor restart' | docker exec -i "$containername" bash -x
 
 
 set +e

--- a/t/docker/openSUSE:Leap:15.2:Staging:A.sh
+++ b/t/docker/openSUSE:Leap:15.2:Staging:A.sh
@@ -69,4 +69,23 @@ grep -q 'scheduled_product_id => 1' /opt/openqa-trigger-from-obs/openSUSE:Leap:1
 
 state=$(echo "select state from minion_jobs where task='obs_rsync_run';" | su postgres -c "psql -t $dbname")
 test "$(echo $state)" == finished
+
+# run second time, make sure all is set
+# rm /opt/openqa-trigger-from-obs/openSUSE:Leap:15.2:Staging:A/.run_last
+echo "delete from minion_jobs where task='obs_rsync_run';" | su postgres -c "psql -t $dbname"
+
+
+mv /mockOBS/openSUSE\:Leap\:15.2\:Staging\:A/images/x86_64/product/openSUSE-Leap-15.2-DVD-x86_64-Build{248.1,248.2}-Media.iso
+mv /mockOBS/openSUSE\:Leap\:15.2\:Staging\:A/images/x86_64/product/openSUSE-Leap-15.2-DVD-x86_64-Build{248.1,248.2}-Media.iso.sha256
+
+openqa-client --host localhost /api/v1/obs_rsync/openSUSE:Leap:15.2:Staging:A/runs put || :
+sleep 10
+
+test -f /var/lib/openqa/factory/iso/openSUSE-Leap-15.2-Staging:A-Staging-DVD-x86_64-Build248.2-Media.iso
+test -f /opt/openqa-trigger-from-obs/openSUSE:Leap:15.2:Staging:A/.run_last/openqa.cmd.log
+grep -q 'scheduled_product_id => 2' /opt/openqa-trigger-from-obs/openSUSE:Leap:15.2:Staging:A/.run_last/openqa.cmd.log
+
+state=$(echo "select state from minion_jobs where task='obs_rsync_run';" | su postgres -c "psql -t $dbname")
+test "$(echo $state)" == finished
+test "$(ls -1q /opt/openqa-trigger-from-obs/openSUSE:Leap:15.2:Staging:A/.run* | wc -l)" -ge 3
 echo PASS ${BASH_SOURCE[0]}


### PR DESCRIPTION
Root cause of the problem is that `ln -f` wants to create temporary file in destination folder when target already exists and that wasn't allowed by apparmor and didn't have proper test.
rsync.sh has strict rules for writing destinations to protect scripts created during deployment.
Thus this fix avoids using -f flag in `ln` and makes sure that .run_last link is deleted before linking to most recent run (plus provides corresponding checks in the test)