### PR TITLE
Copy status files to .run* folder

### DIFF
--- a/script/rsync.sh
+++ b/script/rsync.sh
@@ -50,8 +50,12 @@ set +e
     # store state of files for eventual troubleshooting and avoid indefinite openqa retry
     cp $subfolder/*.lst $logdir/
     cp $subfolder/*.sh $logdir/
+    # copy eventual status files
+    for f in $environ/.* ; do
+        [ ! -f "$f" ] || cp $f $logdir/
+    done
 
-    # remove symbolic link if exists
+    # remove symbolic link if exists, because ln -f needs additional permissions for apparmor
     [ ! -L "$subfolder/.run_last" ] || rm "$subfolder/.run_last"
     ln -s -T "$(pwd)/$logdir" $subfolder/.run_last
 

--- a/t/docker/Virtualization:WSL.sh
+++ b/t/docker/Virtualization:WSL.sh
@@ -7,6 +7,7 @@ cd /opt/openqa-trigger-from-obs
 mkdir -p Virtualization:WSL/Tumbleweed
 python3 script/scriptgen.py Virtualization:WSL
 [ ! -e Virtualization:WSL/Tumbleweed/.run_last ] || rm Virtualization:WSL/Tumbleweed/.run_last
+[ ! -e Virtualization:WSL/Leap_15.2/.run_last ] || rm Virtualization:WSL/Leap_15.2/.run_last
 echo geekotest > rsync.secret
 chmod 600 rsync.secret'
 
@@ -64,7 +65,7 @@ set -x
 # make sure run did happen
 test -f /var/lib/openqa/factory/other/openSUSE-Tumbleweed-x64-Build20191128.7.9.appx
 test -f /opt/openqa-trigger-from-obs/Virtualization:WSL/Tumbleweed/.run_last/openqa.cmd.log
-grep -q 'scheduled_product_id => 1' /opt/openqa-trigger-from-obs/Virtualization:WSL/Tumbleweed/.run_last/openqa.cmd.log
+grep -q 'scheduled_product_id => 1' /opt/openqa-trigger-from-obs/Virtualization:WSL/{Tumbleweed,Leap_15.2}/.run_last/openqa.cmd.log
 
 state=$(echo "select state from minion_jobs where task='obs_rsync_run';" | su postgres -c "psql -t $dbname")
 test "$(echo $state)" == finished

--- a/t/docker/rsync.sh.Virtualization:WSL.sh
+++ b/t/docker/rsync.sh.Virtualization:WSL.sh
@@ -7,6 +7,7 @@ cd /opt/openqa-trigger-from-obs
 mkdir -p Virtualization:WSL/Tumbleweed
 python3 script/scriptgen.py Virtualization:WSL
 [ ! -e Virtualization:WSL/Tumbleweed/.run_last ] || rm Virtualization:WSL/Tumbleweed/.run_last
+[ ! -e Virtualization:WSL/Leap_15.2/.run_last ] || rm Virtualization:WSL/Leap_15.2/.run_last
 echo geekotest > rsync.secret
 chmod 600 rsync.secret'
 
@@ -56,6 +57,8 @@ chown "$dbuser" /var/lib/openqa/.config/openqa/client.conf
 
 systemctl enable --now rsyncd
 
+echo 111 > /opt/openqa-trigger-from-obs/Virtualization:WSL/.job_id
+
 su "$dbuser" -c '/opt/openqa-trigger-from-obs/script/rsync.sh Virtualization:WSL'
 
 sleep 10
@@ -63,6 +66,8 @@ set -x
 # make sure run did happen
 test -f /var/lib/openqa/factory/other/openSUSE-Tumbleweed-x64-Build20191128.7.9.appx
 test -f /opt/openqa-trigger-from-obs/Virtualization:WSL/Tumbleweed/.run_last/openqa.cmd.log
-grep -q 'scheduled_product_id => 1' /opt/openqa-trigger-from-obs/Virtualization:WSL/Tumbleweed/.run_last/openqa.cmd.log
+test -f /opt/openqa-trigger-from-obs/Virtualization:WSL/Tumbleweed/.run_last/.job_id
+test 111 == "$(cat /opt/openqa-trigger-from-obs/Virtualization:WSL/Tumbleweed/.run_last/.job_id)"
+grep -q 'scheduled_product_id => 1' /opt/openqa-trigger-from-obs/Virtualization:WSL/{Tumbleweed,Leap_15.2}/.run_last/openqa.cmd.log
 
 echo PASS ${BASH_SOURCE[0]}


### PR DESCRIPTION
Save current status files (e.g. minion's job_id) into log folder .run to show later in ObsRsync UI https://github.com/os-autoinst/openQA/pull/2534